### PR TITLE
Responsive framework and use of REM for textsize

### DIFF
--- a/app/css/base.css
+++ b/app/css/base.css
@@ -3,15 +3,42 @@ html {
     -moz-box-sizing: border-box;
     box-sizing: border-box;
     -webkit-font-smoothing: antialiased;
-    font-size: 16px;
+    font-size: 100%;
     font-weight: normal;
-    line-height: 1.5;
+    line-height: 1.3;
     background-color: var(--background);
     -webkit-text-size-adjust: 100%;
     -ms-text-size-adjust: 100%;
     height: 100vh;
     width: 100vw;
-
+}
+/* For webbrowsers with screensize relative to large mobile or small tab  */
+@media screen and (min-width: 479px) {
+      html  {font-size: 110%;
+      -webkit-text-size-adjust: 110%;
+      -ms-text-size-adjust: 110%;
+      }
+}
+/* For webbrowsers with screensize relative to large tab  */
+@media screen and (min-width: 767px) {
+     html {font-size: 120%;
+      -webkit-text-size-adjust: 120%;
+      -ms-text-size-adjust: 120%;
+    }
+}
+/* For webbrowsers with screensize relative to small computer screen  */
+@media screen and (min-width: 991px) {
+     html {font-size: 125%;
+      -webkit-text-size-adjust: 125%;
+      -ms-text-size-adjust: 125%;
+    }
+}
+/* For webbrowsers with screensize relative to large computer screen  */
+@media screen and (min-width: 1350px) {
+     html {font-size: 140%;
+      -webkit-text-size-adjust: 140%;
+      -ms-text-size-adjust: 140%;
+    }
 }
 *, *:before, *:after {
     -webkit-box-sizing: inherit;
@@ -45,7 +72,7 @@ a{
     text-decoration: none;
     cursor: pointer;
 }
-button.underline-link, 
+button.underline-link,
 a.underline-link {
 	  position: relative;
 	  /* color: var(--primary); */
@@ -60,8 +87,8 @@ a.underline-link::before {
 	  content: "";
 	  position: absolute;
 	  width: 100%;
-	  height: 3px;
-	  bottom: -5px;
+	  height: 0.15rem;
+	  bottom: -0.3rem;
 	  left: 0;
 	  background-color: var(--primary);
 	  visibility: hidden;
@@ -97,13 +124,13 @@ sup {
     vertical-align: baseline;
 }
 sup {
-    top: -0.5em;
+    top: -0.5rem;
 }
 sub {
-    bottom: -0.25em;
+    bottom: -0.25rem;
 }
 blockquote {
-    margin: 0 0 20px 0;
+    margin: 0 0 1.1rem 0;
     font-size: 1.25rem;
     line-height: 1.5;
     font-style: italic;
@@ -122,5 +149,3 @@ summary,
 textarea {
     touch-action: manipulation;
 }
-
-

--- a/app/css/typography.css
+++ b/app/css/typography.css
@@ -1,6 +1,13 @@
 /*  Text fonts */
+h1 {font-size: 1.8rem;}
+h2 {font-size: 1.6rem;}
+h3 {font-size: 1.4rem;}
+h4 {font-size: 1.25rem;}
+h5 {font-size: 1.1rem;}
+h6 {font-size: 0.9rem; font-weight: 600;}
+p {font-size: 0.9rem;}
 
-/* Bold */ 
+/* Bold */
 .sq-bold{ font-weight: bold;}
 
 .sq-bolder{ font-weight: bolder;}
@@ -18,33 +25,33 @@
 /*   Font-size   */
 
 .sq-text-small {
-    font-size: 0.875rem;
+    font-size: 0.84rem;
     line-height: 1.5;}
- 
+
 .sq-text-large {
     font-size: 1.5rem;
-    line-height: 1.5;}  
- 
+    line-height: 1.5;}
+
 /* Text with colors (Muted, Warning, Success and Danger) */
 
 .sq-text-muted { color: #999 !important;}
-    
-.sq-text-success { color: #32d296 !important;} 
+
+.sq-text-success { color: #32d296 !important;}
 
 .sq-text-warning { color: #faa05a !important;}
-    
+
 .sq-text-danger { color: #f0506e !important;}
-   
+
 /*   Text Tranform-modifiers   */
 
 .sq-text-uppercase {text-transform: uppercase !important;}
-      
+
 .sq-text-capitalize {text-transform: capitalize !important;}
-    
+
 .sq-text-lowercase {text-transform: lowercase !important;}
-    
-  
-/* Text-Decoration Lines */ 
+
+
+/* Text-Decoration Lines */
 
 .sq-overline{ text-decoration: overline;}
 
@@ -62,8 +69,8 @@
     line-height: 60px;
     padding-top: 4px;
     padding-right: 8px;
-    padding-left: 3px;} 
-  
+    padding-left: 3px;}
+
 p:first-child:first-letter {
     color: #903;
     float: left;
@@ -73,18 +80,14 @@ p:first-child:first-letter {
     padding-top:0px;
     padding-right: 0px;
     padding-left: 3px;
-  } 
-  
-  
+  }
 
 /* Text align */
 
 .sq-text-left {text-align: left !important;}
-      
+
 .sq-text-right {text-align: right !important;}
-      
+
 .sq-text-center {text-align: center !important;}
-      
+
 .sq-text-justify {text-align: justify !important;}
-    
-  


### PR DESCRIPTION
In base.css:  Set base font-size in html to 100% (for small mobiles). Added @media for large mobiles (110% font size), tabs (120% font size), smal computer screens (120% font size) and large computer screens (125% font size). Changed sizes in PX and EM to relative size in REM.
In typography.css: added css styles for tags P and H1-H6. Adjusted class .sq-text-small from 0.875rem to 0.84rem